### PR TITLE
Distributed systems: fix SimPy link

### DIFF
--- a/01_Intro_To_Distributed_Systems.ipynb
+++ b/01_Intro_To_Distributed_Systems.ipynb
@@ -22,7 +22,7 @@
     "\n",
     "We will simulate the P2P environment locally to get an idea of how such systems would work and understand the design decision that developers make.\n",
     "\n",
-    "To show the different tradeoffs and why developers and researchers choose specific designs, we need a way to simulate such an environment. Here we will simulate the network and message exchange via a  discrete event simulator: [SimPy](simpy.readthedocs.io/en/latest/).\n",
+    "To show the different tradeoffs and why developers and researchers choose specific designs, we need a way to simulate such an environment. Here we will simulate the network and message exchange via a  discrete event simulator: [SimPy](https://simpy.readthedocs.io/en/latest/).\n",
     "\n",
     "For the simplicity of use, you can use wrapper for SimPY implement a P2P network simulation: `p2psimpy`. \n",
     "\n",


### PR DESCRIPTION
Use absolute link so that GitHub does not append `render.githubusercontent.com/view`.